### PR TITLE
Use aux fields to hold detadt

### DIFF
--- a/grandPotential-paraboloid/BC_AMR.prm
+++ b/grandPotential-paraboloid/BC_AMR.prm
@@ -3,6 +3,8 @@
 
 set Boundary condition for variable LIQUID_0 = NATURAL
 set Boundary condition for variable SOLID_0 = NATURAL
+set Boundary condition for variable LIQUID_0_detadt = NATURAL
+set Boundary condition for variable SOLID_0_detadt = NATURAL
 set Boundary condition for variable mu_CU = NATURAL
 set Boundary condition for variable mu_TI = NATURAL
 

--- a/grandPotential-paraboloid/ParaboloidSystem.h
+++ b/grandPotential-paraboloid/ParaboloidSystem.h
@@ -439,12 +439,10 @@ public:
     std::vector<std::string> op_names = get_order_parameter_names();
     std::vector<std::string> grad_op_names;
     std::vector<std::string> op_detadt_names;
-    std::vector<std::string> grad_op_detadt_names;
     for (const auto &op_name : op_names)
       {
         grad_op_names.push_back("grad(" + op_name + ")");
         op_detadt_names.push_back(op_name + "_detadt");
-        grad_op_detadt_names.push_back("grad(" + op_detadt_names.back() + ")");
         std::cout << op_name << " ";
       }
     std::cout << "\n";
@@ -474,7 +472,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
@@ -492,7 +489,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-paraboloid/ParaboloidSystem.h
+++ b/grandPotential-paraboloid/ParaboloidSystem.h
@@ -457,8 +457,14 @@ public:
         loader->set_need_value_nucleation(var_index, true);
         loader->insert_dependencies_value_term_RHS(var_index, mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_detadt_names);
         var_index++;
       }
     for (const auto &op_name : op_names)
@@ -467,15 +473,8 @@ public:
         loader->set_variable_type(var_index, SCALAR);
         loader->set_variable_equation_type(var_index, EXPLICIT_TIME_DEPENDENT);
         loader->set_need_value_nucleation(var_index, true);
-        loader->insert_dependencies_value_term_RHS(var_index, mu_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
         var_index++;
       }
     for (const auto &op_name : op_names)
@@ -488,7 +487,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
-        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-paraboloid/ParaboloidSystem.h
+++ b/grandPotential-paraboloid/ParaboloidSystem.h
@@ -438,9 +438,13 @@ public:
     // Get names for order parameter fields
     std::vector<std::string> op_names = get_order_parameter_names();
     std::vector<std::string> grad_op_names;
+    std::vector<std::string> op_detadt_names;
+    std::vector<std::string> grad_op_detadt_names;
     for (const auto &op_name : op_names)
       {
         grad_op_names.push_back("grad(" + op_name + ")");
+        op_detadt_names.push_back(op_name + "_detadt");
+        grad_op_detadt_names.push_back("grad(" + op_detadt_names.back() + ")");
         std::cout << op_name << " ";
       }
     std::cout << "\n";
@@ -469,6 +473,26 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
+        var_index++;
+      }
+    for (const auto &op_name : op_names)
+      {
+        loader->set_variable_name(var_index, op_name + "_detadt");
+        loader->set_variable_type(var_index, SCALAR);
+        loader->set_variable_equation_type(var_index, AUXILIARY);
+        loader->set_need_value_nucleation(var_index, true);
+        loader->insert_dependencies_value_term_RHS(var_index, mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-paraboloid/SystemContainer.h
+++ b/grandPotential-paraboloid/SystemContainer.h
@@ -387,7 +387,7 @@ public:
         variable_list.set_scalar_value_term_RHS(var_index,
                                                 op.eta.val +
                                                   op.detadt_field * userInputs->dtValue);
-        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec * 0.0);
+        variable_list.set_scalar_gradient_term_RHS(var_index, scalarGrad());
         var_index++;
       }
   }
@@ -402,14 +402,8 @@ public:
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
     uint                                                            &var_index)
   {
-    for (uint comp_index = 0; comp_index < comp_data.size(); comp_index++)
-      {
-        var_index++;
-      }
-    for (auto &[phase_index, op] : op_data)
-      {
-        var_index++;
-      }
+    var_index += comp_data.size(); // Skip the mu fields
+    var_index += op_data.size();   // Skip the op fields
     for (auto &[phase_index, op] : op_data)
       {
         variable_list.set_scalar_value_term_RHS(var_index, op.detadt.val);

--- a/grandPotential-paraboloid/SystemContainer.h
+++ b/grandPotential-paraboloid/SystemContainer.h
@@ -53,6 +53,7 @@ public:
   {
     scalarField              eta;
     scalarVariation          detadt;
+    scalarValue              detadt_field = dealii::make_vectorized_array(0.);
     std::vector<scalarField> dhdeta;
   };
 
@@ -120,6 +121,8 @@ public:
         OPData op;
         op.eta.val  = variable_list.get_scalar_value(var_index);
         op.eta.grad = variable_list.get_scalar_gradient(var_index);
+        op.detadt_field =
+          variable_list.get_scalar_value(var_index + isoSys->order_params.size());
         op.dhdeta.resize(isoSys->phases.size());
         op_data.push_back({phase_index, op});
         var_index++;
@@ -337,7 +340,7 @@ public:
                 dcdeta_sum += op.dhdeta.at(beta_index) *
                               (comp.mu / comp_info.k_well + comp_info.c_min);
               }
-            comp.dmudt -= dcdeta_sum * op.detadt;
+            comp.dmudt -= dcdeta_sum.val * op.detadt_field;
           }
 
         // Convert from dcdt to dmudt
@@ -383,9 +386,34 @@ public:
       {
         variable_list.set_scalar_value_term_RHS(var_index,
                                                 op.eta.val +
-                                                  op.detadt.val * userInputs->dtValue);
-        variable_list.set_scalar_gradient_term_RHS(var_index,
-                                                   -op.detadt.vec * userInputs->dtValue);
+                                                  op.detadt_field * userInputs->dtValue);
+        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec * 0.0);
+        var_index++;
+      }
+  }
+
+  /**
+   * @brief Submit the fields to PRISMS-PF
+   * @param variable_list The PRISMS-PF variable list
+   * @param var_index The starting index for the block of fields
+   */
+  void
+  submit_aux_fields(
+    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
+    uint                                                            &var_index)
+  {
+    for (uint comp_index = 0; comp_index < comp_data.size(); comp_index++)
+      {
+        var_index++;
+      }
+    for (auto &[phase_index, op] : op_data)
+      {
+        var_index++;
+      }
+    for (auto &[phase_index, op] : op_data)
+      {
+        variable_list.set_scalar_value_term_RHS(var_index, op.detadt.val);
+        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec);
         var_index++;
       }
   }

--- a/grandPotential-paraboloid/SystemContainer.h
+++ b/grandPotential-paraboloid/SystemContainer.h
@@ -130,6 +130,35 @@ public:
   }
 
   /**
+   * @brief Initialize the fields for the PDE
+   * @param variable_list The variable list
+   * @param var_index The starting index for the block of fields
+   */
+  void
+  initialize_fields_nonexplicit(
+    const variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
+    uint                                                                  &var_index)
+  {
+    op_data.clear();
+    op_data.reserve(isoSys->order_params.size());
+    for (uint comp_index = 0; comp_index < isoSys->comp_names.size(); comp_index++)
+      {
+        comp_data[comp_index].mu.val  = variable_list.get_scalar_value(var_index);
+        comp_data[comp_index].mu.grad = variable_list.get_scalar_gradient(var_index);
+        var_index++;
+      }
+    for (const auto &phase_index : isoSys->order_params)
+      {
+        OPData op;
+        op.eta.val  = variable_list.get_scalar_value(var_index);
+        op.eta.grad = variable_list.get_scalar_gradient(var_index);
+        op.dhdeta.resize(isoSys->phases.size());
+        op_data.push_back({phase_index, op});
+        var_index++;
+      }
+  }
+
+  /**
    * @brief Initialize the fields needed for the postprocess
    * @param variable_list The variable list
    * @param var_index The starting index for the block of fields

--- a/grandPotential-paraboloid/customPDE.h
+++ b/grandPotential-paraboloid/customPDE.h
@@ -128,6 +128,7 @@ private:
           {
             {constV(1.), {}}, // eta
             {constV(0.), {}}, // detadt
+            constV(0.), // detadt_field
             {}                // dhdeta
           }
         });

--- a/grandPotential-paraboloid/equations.cc
+++ b/grandPotential-paraboloid/equations.cc
@@ -59,8 +59,12 @@ customPDE<dim, degree>::explicitEquationRHS(
   SystemContainer<dim, degree> sys(isoSys, userInputs);
   uint                         var_index = 0;
   sys.initialize_fields_explicit(variable_list, var_index);
-  sys.calculate_locals();
-  sys.calculate_detadt();
+
+  sys.calculate_sum_sq_eta();
+  sys.calculate_h();
+  sys.calculate_dhdeta();
+  sys.calculate_local_mobility();
+
   sys.calculate_dmudt();
   var_index = 0;
   sys.submit_fields(variable_list, var_index);
@@ -103,10 +107,14 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 {
   SystemContainer<dim, degree> sys(isoSys, userInputs);
   uint                         var_index = 0;
-  sys.initialize_fields_explicit(variable_list, var_index);
-  sys.calculate_locals();
+  sys.initialize_fields_nonexplicit(variable_list, var_index);
+
+  sys.calculate_omega_phase();
+  sys.calculate_sum_sq_eta();
+  sys.calculate_h();
+  sys.calculate_dhdeta();
+
   sys.calculate_detadt();
-  sys.calculate_dmudt();
   var_index = 0;
   sys.submit_aux_fields(variable_list, var_index);
 }

--- a/grandPotential-paraboloid/equations.cc
+++ b/grandPotential-paraboloid/equations.cc
@@ -100,7 +100,16 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
   [[maybe_unused]] const VectorizedArray<double> element_volume) const
-{}
+{
+  SystemContainer<dim, degree> sys(isoSys, userInputs);
+  uint                         var_index = 0;
+  sys.initialize_fields_explicit(variable_list, var_index);
+  sys.calculate_locals();
+  sys.calculate_detadt();
+  sys.calculate_dmudt();
+  var_index = 0;
+  sys.submit_aux_fields(variable_list, var_index);
+}
 
 // =============================================================================================
 // equationLHS (needed only if at least one equation is time independent)

--- a/grandPotential-paraboloid/generate_bc_amr.cc
+++ b/grandPotential-paraboloid/generate_bc_amr.cc
@@ -123,6 +123,11 @@ main(int argc, char *argv[])
       prmFile << "set Boundary condition for variable " << op_name << " = " << condition
               << "\n";
     }
+  for (const std::string &op_name : system.get_order_parameter_names())
+    {
+      prmFile << "set Boundary condition for variable " << op_name + "_detadt"
+              << " = " << condition << "\n";
+    }
   for (const std::string &comp_name : system.get_component_names())
     {
       std::string var_name = "mu_" + comp_name;

--- a/grandPotential-quadratic-form/BC_AMR.prm
+++ b/grandPotential-quadratic-form/BC_AMR.prm
@@ -3,6 +3,8 @@
 
 set Boundary condition for variable LIQUID_0 = NATURAL
 set Boundary condition for variable SOLID_0 = NATURAL
+set Boundary condition for variable LIQUID_0_detadt = NATURAL
+set Boundary condition for variable SOLID_0_detadt = NATURAL
 set Boundary condition for variable mu_CU = NATURAL
 set Boundary condition for variable mu_TI = NATURAL
 

--- a/grandPotential-quadratic-form/ParaboloidSystem.h
+++ b/grandPotential-quadratic-form/ParaboloidSystem.h
@@ -511,12 +511,10 @@ public:
     std::vector<std::string> op_names = get_order_parameter_names();
     std::vector<std::string> grad_op_names;
     std::vector<std::string> op_detadt_names;
-    std::vector<std::string> grad_op_detadt_names;
     for (const auto &op_name : op_names)
       {
         grad_op_names.push_back("grad(" + op_name + ")");
         op_detadt_names.push_back(op_name + "_detadt");
-        grad_op_detadt_names.push_back("grad(" + op_detadt_names.back() + ")");
         std::cout << op_name << " ";
       }
     std::cout << "\n";
@@ -546,7 +544,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
@@ -564,7 +561,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-quadratic-form/ParaboloidSystem.h
+++ b/grandPotential-quadratic-form/ParaboloidSystem.h
@@ -529,8 +529,14 @@ public:
         loader->set_need_value_nucleation(var_index, true);
         loader->insert_dependencies_value_term_RHS(var_index, mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_detadt_names);
         var_index++;
       }
     for (const auto &op_name : op_names)
@@ -539,15 +545,8 @@ public:
         loader->set_variable_type(var_index, SCALAR);
         loader->set_variable_equation_type(var_index, EXPLICIT_TIME_DEPENDENT);
         loader->set_need_value_nucleation(var_index, true);
-        loader->insert_dependencies_value_term_RHS(var_index, mu_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
-        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
-        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
         var_index++;
       }
     for (const auto &op_name : op_names)
@@ -560,7 +559,6 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
-        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-quadratic-form/ParaboloidSystem.h
+++ b/grandPotential-quadratic-form/ParaboloidSystem.h
@@ -510,9 +510,13 @@ public:
     // Get names for order parameter fields
     std::vector<std::string> op_names = get_order_parameter_names();
     std::vector<std::string> grad_op_names;
+    std::vector<std::string> op_detadt_names;
+    std::vector<std::string> grad_op_detadt_names;
     for (const auto &op_name : op_names)
       {
         grad_op_names.push_back("grad(" + op_name + ")");
+        op_detadt_names.push_back(op_name + "_detadt");
+        grad_op_detadt_names.push_back("grad(" + op_detadt_names.back() + ")");
         std::cout << op_name << " ";
       }
     std::cout << "\n";
@@ -541,6 +545,26 @@ public:
         loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_value_term_RHS(var_index, op_names);
         loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, op_names);
+        loader->insert_dependencies_gradient_term_RHS(var_index, grad_op_names);
+        var_index++;
+      }
+    for (const auto &op_name : op_names)
+      {
+        loader->set_variable_name(var_index, op_name + "_detadt");
+        loader->set_variable_type(var_index, SCALAR);
+        loader->set_variable_equation_type(var_index, AUXILIARY);
+        loader->set_need_value_nucleation(var_index, true);
+        loader->insert_dependencies_value_term_RHS(var_index, mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_mu_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_names);
+        loader->insert_dependencies_value_term_RHS(var_index, op_detadt_names);
+        loader->insert_dependencies_value_term_RHS(var_index, grad_op_detadt_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, grad_mu_names);
         loader->insert_dependencies_gradient_term_RHS(var_index, op_names);

--- a/grandPotential-quadratic-form/SystemContainer.h
+++ b/grandPotential-quadratic-form/SystemContainer.h
@@ -69,6 +69,7 @@ public:
   {
     scalarField              eta;
     scalarVariation          detadt;
+    scalarValue              detadt_field = dealii::make_vectorized_array(0.);
     std::vector<scalarField> dhdeta;
   };
 
@@ -137,6 +138,8 @@ public:
         OPData op;
         op.eta.val  = variable_list.get_scalar_value(var_index);
         op.eta.grad = variable_list.get_scalar_gradient(var_index);
+        op.detadt_field =
+          variable_list.get_scalar_value(var_index + isoSys->order_params.size());
         op.dhdeta.resize(isoSys->phases.size());
         op_data.push_back({phase_index, op});
         var_index++;
@@ -393,7 +396,7 @@ public:
         // dmudt -= op.detadt * dcdeta_sum; // NOTATION
         for (uint comp_index = 0; comp_index < isoSys->num_comps; comp_index++)
           {
-            dmudt[comp_index] -= op.detadt * dcdeta_sum[comp_index];
+            dmudt[comp_index] -= op.detadt_field * dcdeta_sum[comp_index].val;
           }
       }
     // Convert from dcdt to dmudt
@@ -440,9 +443,34 @@ public:
       {
         variable_list.set_scalar_value_term_RHS(var_index,
                                                 op.eta.val +
-                                                  op.detadt.val * userInputs->dtValue);
-        variable_list.set_scalar_gradient_term_RHS(var_index,
-                                                   -op.detadt.vec * userInputs->dtValue);
+                                                  op.detadt_field * userInputs->dtValue);
+        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec * 0.0);
+        var_index++;
+      }
+  }
+
+  /**
+   * @brief Submit the fields to PRISMS-PF
+   * @param variable_list The PRISMS-PF variable list
+   * @param var_index The starting index for the block of fields
+   */
+  void
+  submit_aux_fields(
+    variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
+    uint                                                            &var_index)
+  {
+    for (uint comp_index = 0; comp_index < isoSys->num_comps; comp_index++)
+      {
+        var_index++;
+      }
+    for (auto &[phase_index, op] : op_data)
+      {
+        var_index++;
+      }
+    for (auto &[phase_index, op] : op_data)
+      {
+        variable_list.set_scalar_value_term_RHS(var_index, op.detadt.val);
+        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec);
         var_index++;
       }
   }

--- a/grandPotential-quadratic-form/SystemContainer.h
+++ b/grandPotential-quadratic-form/SystemContainer.h
@@ -444,7 +444,7 @@ public:
         variable_list.set_scalar_value_term_RHS(var_index,
                                                 op.eta.val +
                                                   op.detadt_field * userInputs->dtValue);
-        variable_list.set_scalar_gradient_term_RHS(var_index, -op.detadt.vec * 0.0);
+        variable_list.set_scalar_gradient_term_RHS(var_index, scalarGrad());
         var_index++;
       }
   }
@@ -459,14 +459,8 @@ public:
     variableContainer<dim, degree, dealii::VectorizedArray<double>> &variable_list,
     uint                                                            &var_index)
   {
-    for (uint comp_index = 0; comp_index < isoSys->num_comps; comp_index++)
-      {
-        var_index++;
-      }
-    for (auto &[phase_index, op] : op_data)
-      {
-        var_index++;
-      }
+    var_index += isoSys->num_comps;           // Skip the mu fields
+    var_index += isoSys->order_params.size(); // Skip the op fields
     for (auto &[phase_index, op] : op_data)
       {
         variable_list.set_scalar_value_term_RHS(var_index, op.detadt.val);

--- a/grandPotential-quadratic-form/customPDE.h
+++ b/grandPotential-quadratic-form/customPDE.h
@@ -128,6 +128,7 @@ private:
           {
             {constV(1.), {}}, // eta
             {constV(0.), {}}, // detadt
+            constV(0.), // detadt_field
             {}                // dhdeta
           }
         });

--- a/grandPotential-quadratic-form/equations.cc
+++ b/grandPotential-quadratic-form/equations.cc
@@ -101,7 +101,16 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
   [[maybe_unused]] variableContainer<dim, degree, VectorizedArray<double>> &variable_list,
   [[maybe_unused]] const Point<dim, VectorizedArray<double>>                q_point_loc,
   [[maybe_unused]] const VectorizedArray<double> element_volume) const
-{}
+{
+  SystemContainer<dim, degree> sys(isoSys, userInputs);
+  uint                         var_index = 0;
+  sys.initialize_fields_explicit(variable_list, var_index);
+  sys.calculate_locals();
+  sys.calculate_detadt();
+  sys.calculate_dmudt();
+  var_index = 0;
+  sys.submit_aux_fields(variable_list, var_index);
+}
 
 // =============================================================================================
 // equationLHS (needed only if at least one equation is time independent)

--- a/grandPotential-quadratic-form/equations.cc
+++ b/grandPotential-quadratic-form/equations.cc
@@ -59,8 +59,13 @@ customPDE<dim, degree>::explicitEquationRHS(
   SystemContainer<dim, degree> sys(isoSys, userInputs);
   uint                         var_index = 0;
   sys.initialize_fields_explicit(variable_list, var_index);
-  sys.calculate_locals();
-  sys.calculate_detadt();
+
+  sys.calculate_deltas();
+  sys.calculate_sum_sq_eta();
+  sys.calculate_h();
+  sys.calculate_dhdeta();
+  sys.calculate_local_mobility();
+
   sys.calculate_dmudt();
   var_index = 0;
   sys.submit_fields(variable_list, var_index);
@@ -104,10 +109,15 @@ customPDE<dim, degree>::nonExplicitEquationRHS(
 {
   SystemContainer<dim, degree> sys(isoSys, userInputs);
   uint                         var_index = 0;
-  sys.initialize_fields_explicit(variable_list, var_index);
-  sys.calculate_locals();
+  sys.initialize_fields_nonexplicit(variable_list, var_index);
+
+  sys.calculate_deltas();
+  sys.calculate_omega_phase();
+  sys.calculate_sum_sq_eta();
+  sys.calculate_h();
+  sys.calculate_dhdeta();
+
   sys.calculate_detadt();
-  sys.calculate_dmudt();
   var_index = 0;
   sys.submit_aux_fields(variable_list, var_index);
 }

--- a/grandPotential-quadratic-form/generate_bc_amr.cc
+++ b/grandPotential-quadratic-form/generate_bc_amr.cc
@@ -123,6 +123,11 @@ main(int argc, char *argv[])
       prmFile << "set Boundary condition for variable " << op_name << " = " << condition
               << "\n";
     }
+  for (const std::string &op_name : system.get_order_parameter_names())
+    {
+      prmFile << "set Boundary condition for variable " << op_name + "_detadt"
+              << " = " << condition << "\n";
+    }
   for (const std::string &comp_name : system.get_component_names())
     {
       std::string var_name = "mu_" + comp_name;


### PR DESCRIPTION
For some reason, the expanded variational form was not working for the coupled term in the chemical potential evolution. This switches it to a more trad method of storing the field instead. 
